### PR TITLE
[Refactor] Refactoring CancelMembershipView

### DIFF
--- a/HARUCHI/HARUCHI.xcodeproj/project.pbxproj
+++ b/HARUCHI/HARUCHI.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		378A0FF12C6FCC12002D932A /* MemberInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378A0FF02C6FCC12002D932A /* MemberInfoViewModel.swift */; };
 		378A0FF52C712E46002D932A /* MemberInfoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378A0FF42C712E46002D932A /* MemberInfoService.swift */; };
 		3797F3DA2C73CC6E00048A18 /* ReconfirmButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3797F3D92C73CC6E00048A18 /* ReconfirmButton.swift */; };
+		3797F3DC2C73DCA100048A18 /* FinalConfirmButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3797F3DB2C73DCA100048A18 /* FinalConfirmButton.swift */; };
 		37CD69372C724B8C000137FC /* CancelMembershipAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CD69362C724B8C000137FC /* CancelMembershipAPI.swift */; };
 		37CD69392C724D12000137FC /* CancelMembershipService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CD69382C724D12000137FC /* CancelMembershipService.swift */; };
 		37CD693B2C724D8A000137FC /* BaseWithOutResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CD693A2C724D8A000137FC /* BaseWithOutResult.swift */; };
@@ -93,6 +94,7 @@
 		378A0FF02C6FCC12002D932A /* MemberInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberInfoViewModel.swift; sourceTree = "<group>"; };
 		378A0FF42C712E46002D932A /* MemberInfoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberInfoService.swift; sourceTree = "<group>"; };
 		3797F3D92C73CC6E00048A18 /* ReconfirmButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReconfirmButton.swift; sourceTree = "<group>"; };
+		3797F3DB2C73DCA100048A18 /* FinalConfirmButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinalConfirmButton.swift; sourceTree = "<group>"; };
 		37CD69362C724B8C000137FC /* CancelMembershipAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelMembershipAPI.swift; sourceTree = "<group>"; };
 		37CD69382C724D12000137FC /* CancelMembershipService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelMembershipService.swift; sourceTree = "<group>"; };
 		37CD693A2C724D8A000137FC /* BaseWithOutResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseWithOutResult.swift; sourceTree = "<group>"; };
@@ -333,6 +335,7 @@
 				9FAB27002C5FB31D007FDD23 /* SmallCircleButton.swift */,
 				C6CF822E2C6A77740006A98C /* LoadingView.swift */,
 				3797F3D92C73CC6E00048A18 /* ReconfirmButton.swift */,
+				3797F3DB2C73DCA100048A18 /* FinalConfirmButton.swift */,
 				C6C13A242C4D17A900AE2D9C /* ViewModifier */,
 			);
 			path = Components;
@@ -561,6 +564,7 @@
 				C6CF82292C6A5D5B0006A98C /* Base.swift in Sources */,
 				C695BDA92C60E05C009DEC3C /* AuthAPI.swift in Sources */,
 				9F161E872C6DDA7A00E0537B /* ExpenditureAPI.swift in Sources */,
+				3797F3DC2C73DCA100048A18 /* FinalConfirmButton.swift in Sources */,
 				9F6799352C6DD92B00AEF96A /* IncomeAPI.swift in Sources */,
 				378A0FED2C6FC032002D932A /* MemberInfoAPI.swift in Sources */,
 				37CD693B2C724D8A000137FC /* BaseWithOutResult.swift in Sources */,

--- a/HARUCHI/HARUCHI/App/Detail/CancelMembershipView.swift
+++ b/HARUCHI/HARUCHI/App/Detail/CancelMembershipView.swift
@@ -4,6 +4,7 @@ struct CancelMembershipView: View {
     @FocusState private var isFocused: Bool // TextEditor의 포커스 상태를 추적
     @StateObject private var viewModel = CancelMembershipViewModel() // ViewModel 객체 생성
     @State private var showReconfirmButton: Bool = false // ReconfirmButton 표시 여부를 제어하는 상태 변수
+    @State private var showFinalConfirmButton: Bool = false // FinalConfirmButton 표시 여부를 제어하는 상태 변수
     
     var body: some View {
         ZStack{
@@ -121,8 +122,24 @@ struct CancelMembershipView: View {
                         showReconfirmButton = false // 취소 버튼을 누르면 오버레이 닫기
                     },
                     onConfirm: {
-                        viewModel.cancelMembership() // 실제 탈퇴 작업 수행
                         showReconfirmButton = false
+                        viewModel.cancelMembership() // 실제 탈퇴 작업 수행
+                        showFinalConfirmButton = true
+                    }
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.clear)
+            }
+            
+            // FinalConfirmButton 오버레이
+            if showFinalConfirmButton {
+                Color.black.opacity(0.6)
+                    .edgesIgnoringSafeArea(.all)
+                
+                FinalConfirmButton(
+                    onOK: {
+                        showFinalConfirmButton = false
+                        viewModel.isCanceled = true // 로그인 화면으로 이동하기 위해 설정
                     }
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/HARUCHI/HARUCHI/App/Detail/CancelMembershipViewModel.swift
+++ b/HARUCHI/HARUCHI/App/Detail/CancelMembershipViewModel.swift
@@ -28,7 +28,7 @@ class CancelMembershipViewModel: ObservableObject {
                 switch completion {
                 case .finished:
                     print("Membership cancellation completed.")
-                    self.isCanceled = true // 성공 시 네비게이션 트리거
+                    //self.isCanceled = true // 성공 시 네비게이션 트리거
                 case .failure(let error):
                     print("Failed to cancel membership with error: \(error)")
                 }

--- a/HARUCHI/HARUCHI/Components/FinalConfirmButton.swift
+++ b/HARUCHI/HARUCHI/Components/FinalConfirmButton.swift
@@ -1,0 +1,37 @@
+//
+//  FinalConfirmButton.swift
+//  HARUCHI
+//
+//  Created by 이슬기 on 8/20/24.
+//
+
+import SwiftUI
+
+struct FinalConfirmButton: View {
+    var body: some View {
+        ZStack{
+            Rectangle()
+                .frame(width: 281, height: 108.73)
+                .foregroundStyle(.white)
+                .cornerRadius(5)
+            VStack(alignment: .leading, spacing: 19.26){
+                Text("탈퇴 처리가 완료되었습니다.")
+                    .font(.haruchi(.body_sb16))
+                    .foregroundStyle(.black)
+                    .frame(width: 178, height: 19)
+                    .padding(.leading, 20)
+                
+                Button(action: {}) {
+                    Text("확인")
+                        .font(.haruchi(size: 12, family: .SemiBold))
+                }.foregroundStyle(Color.mainBlue)
+                    .frame(width: 60, height: 35)
+                    .padding(.leading, 220)
+            }.padding(.top, 11)
+        }
+    }
+}
+
+#Preview {
+    FinalConfirmButton()
+}

--- a/HARUCHI/HARUCHI/Components/FinalConfirmButton.swift
+++ b/HARUCHI/HARUCHI/Components/FinalConfirmButton.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct FinalConfirmButton: View {
+    var onOK: () -> Void // 확인 버튼 클릭 시 실행할 동작
+    
     var body: some View {
         ZStack{
             Rectangle()
@@ -21,7 +23,7 @@ struct FinalConfirmButton: View {
                     .frame(width: 178, height: 19)
                     .padding(.leading, 20)
                 
-                Button(action: {}) {
+                Button(action: onOK) {
                     Text("확인")
                         .font(.haruchi(size: 12, family: .SemiBold))
                 }.foregroundStyle(Color.mainBlue)
@@ -32,6 +34,6 @@ struct FinalConfirmButton: View {
     }
 }
 
-#Preview {
-    FinalConfirmButton()
-}
+//#Preview {
+//    FinalConfirmButton()
+//}


### PR DESCRIPTION
## What is this PR? 👀
Refactoring CancelMembershipView
<br><br/>

## Changes 📃
1. 탈퇴 완료 버튼 컴포넌트에 추가
2. 탈퇴 재확인 -> 탈퇴하기 버튼 누르면 -> 탈퇴 완료 창 -> 확인 버튼 누르면 -> 로그인 창 이동
<br><br/>

## Screenshot (optional) 📷
![화면 기록 2024-08-20 오전 5](https://github.com/user-attachments/assets/839ecf73-5552-4d30-ad44-bf8c98858da4)
<br><br/>

## Additional & Attention points(optional) 🔥

<br><br/>

## Test result 🧪
직접 테스트
